### PR TITLE
adding second option for local storage key

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ If your network team has worked with Tealium to configure a first-party data end
 
 For first-party configurations, you will need to edit the tag Template "Permissions" section before you add the tag itself (Templates -> Template Editor -> Permissions -> Injects Scripts).
 
-2. Add Enrichment Data to dataLayer 
+2. Local Storage Key
+
+This is the location where the data will be written to Local Storage in the browser.  There are two options for this key.  Using the default 'tealium_va' option allows Tealium tag partners (when running their tag on the page) to also leverage this data.
+
+3. Add Enrichment Data to dataLayer 
 
 This checkbox is used if you want to have this tag automatically call dataLayer.push when it finds the enrichment data in Local Storage.  More likely you would use a set of "User Defined Variables" to retreive specific items from Local Storage.  For example, you may want to create a specific Variable (Custom JavaScript) that determines if a Badge is true or false.  Then use this Variable as part of another tag's configuration or Trigger.
 
@@ -43,7 +47,7 @@ This checkbox is used if you want to have this tag automatically call dataLayer.
 
 ## Copyright and license
 
-Copyright 2020 Tealium Inc. All rights reserved.
+Copyright 2021 Tealium Inc. All rights reserved.
 
 Licensed under the **[Apache License, Version 2.0][license]** (the "License");
 you may not use this software except in compliance with the License.

--- a/template.tpl
+++ b/template.tpl
@@ -63,6 +63,25 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
+    "type": "SELECT",
+    "name": "localStorageKey",
+    "displayName": "Local Storage Key",
+    "macrosInSelect": false,
+    "selectItems": [
+      {
+        "value": "tealium_va",
+        "displayValue": "tealium_va"
+      },
+      {
+        "value": "tealium_enrichment_data",
+        "displayValue": "tealium_enrichment_data"
+      }
+    ],
+    "simpleValueType": true,
+    "defaultValue": "tealium_va",
+    "help": "Data will be written to browser Local Storage with this key"
+  },
+  {
     "type": "CHECKBOX",
     "name": "addToDataLayer",
     "checkboxText": "Add Enrichment Data to dataLayer",
@@ -86,6 +105,15 @@ const queryPermission = require('queryPermission');
 const encodeUri = require('encodeUri');
 
 log('data =', data);
+
+var enrichment_location;
+if (data.localStorageKey === "tealium_va") {
+    // The 'tealium_' prefix is added automatically
+    enrichment_location = "va";
+} else {
+    enrichment_location = "enrichment_data";
+}
+
 // a-z, A-Z, 0-9, and . - for GUIDs and GA cookie id
 const validChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-';
 
@@ -157,7 +185,7 @@ const onSuccess = () => {
 };
 
 const localStoragePrefix = 'tealium_',
-    tealium_enrichment_data = readLocalStorage('enrichment_data'),
+    tealium_enrichment_data = readLocalStorage(enrichment_location),
     visitorId = clean(getVisitorId()),
     timestamp = getTimestampMillis(),
     url = encodeUri(data.endpoint + '/' + data.tealiumAccount + '/' + data.tealiumProfile + '/' +
@@ -169,7 +197,7 @@ setInWindow('tealium_gtm_enrich', function(o) {
     // Uses the "tealium_" prefix to write out tealium_enrichment_data
     var str = JSON.stringify(o);
     if (str !== "{}" && str !=="") {
-        writeLocalStorage('enrichment_data', str);
+        writeLocalStorage(enrichment_location, str);
     }
 }, true);
 
@@ -391,6 +419,37 @@ ___WEB_PERMISSIONS___
                   },
                   {
                     "type": 8,
+                    "boolean": true
+                  }
+                ]
+              },
+              { 
+                "type": 3,
+                "mapKey": [
+                  { 
+                    "type": 1,
+                    "string": "key"
+                  },
+                  { 
+                    "type": 1,
+                    "string": "read"
+                  },
+                  { 
+                    "type": 1,
+                    "string": "write"
+                  }
+                ],
+                "mapValue": [
+                  { 
+                    "type": 1,
+                    "string": "tealium_va"
+                  },
+                  { 
+                    "type": 8, 
+                    "boolean": true
+                  },
+                  { 
+                    "type": 8, 
                     "boolean": true
                   }
                 ]


### PR DESCRIPTION
Some Tealium partners have logic that expects to see 'tealium_va' in local storage.